### PR TITLE
fix: Do not move read offset when matching Stdin

### DIFF
--- a/run/cmd.go
+++ b/run/cmd.go
@@ -1,6 +1,9 @@
 package run
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"os/exec"
 )
 
@@ -20,4 +23,31 @@ func (c *Cmd) Output() ([]byte, error) {
 // Run starts the specified command and waits for it to complete.
 func (c *Cmd) Run() error {
 	return c.client.Executor.Run(c)
+}
+
+// PeekStdin reads Stdin without moving the read offset to EOF.
+func (c *Cmd) PeekStdin() ([]byte, error) {
+	if c.Stdin == nil {
+		return nil, nil
+	}
+
+	// io hijinks to reset the read offset
+	copy := &bytes.Buffer{}
+	reader := io.TeeReader(c.Stdin, copy)
+	c.Stdin = copy
+
+	return io.ReadAll(reader)
+}
+
+// DebugString the command string plus a truncated preview of stdin.
+func (c *Cmd) DebugString() string {
+	stdin, _ := c.PeekStdin()
+	if len(stdin) > 20 {
+		stdin = append(stdin[:20], []byte("…")...)
+	}
+	suffix := ""
+	if len(stdin) > 0 {
+		suffix = fmt.Sprintf(" [Stdin: \"%s\"]", string(stdin))
+	}
+	return c.String() + suffix
 }

--- a/run/cmd_test.go
+++ b/run/cmd_test.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"bytes"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,5 +32,45 @@ func TestCmd_Run(t *testing.T) {
 
 	cmd := client.Command("/bin/echo", "foo", "bar")
 	err := cmd.Run()
+	assert.NoError(t, err)
+}
+
+func TestCmd_DebugString(t *testing.T) {
+	client := NewClient()
+
+	cmd := client.Command("/bin/cat")
+	assert.Equal(t, `/bin/cat`, cmd.DebugString())
+
+	cmd.Stdin = bytes.NewBufferString("hello")
+	assert.Equal(t, `/bin/cat [Stdin: "hello"]`, cmd.DebugString())
+
+	cmd.Stdin = bytes.NewBufferString("Lorem ipsum dolor sit amet")
+	assert.Equal(t, `/bin/cat [Stdin: "Lorem ipsum dolor si…"]`, cmd.DebugString())
+}
+
+func TestCmd_PeekStdin(t *testing.T) {
+	client := NewClient()
+	cmd := client.Command("/bin/cat")
+
+	// Stdin not set
+	data, err := cmd.PeekStdin()
+	assert.Equal(t, "", string(data))
+	assert.NoError(t, err)
+
+	cmd.Stdin = bytes.NewBufferString("hello")
+
+	// Std in set
+	data, err = cmd.PeekStdin()
+	assert.Equal(t, "hello", string(data))
+	assert.NoError(t, err)
+
+	// Read offset should still be at the beginning of file
+	data, err = io.ReadAll(cmd.Stdin)
+	assert.Equal(t, "hello", string(data))
+	assert.NoError(t, err)
+
+	// Read offset is now at EOF
+	data, err = io.ReadAll(cmd.Stdin)
+	assert.Equal(t, "", string(data))
 	assert.NoError(t, err)
 }

--- a/run/matcher.go
+++ b/run/matcher.go
@@ -1,13 +1,7 @@
 package run
 
 import (
-	"io"
 	"regexp"
-)
-
-var (
-	// for stubbing
-	ioReadAll = io.ReadAll
 )
 
 // Matcher is function that matches commands.
@@ -33,14 +27,8 @@ func MatchAll(matchers ...Matcher) Matcher {
 // MatchStdin returns a matcher that matches against command stdin.
 func MatchStdin(s string) Matcher {
 	return func(cmd *Cmd) bool {
-		if cmd.Stdin == nil {
-			return false
-		}
-		buf, err := ioReadAll(cmd.Stdin)
-		if err != nil {
-			panic(err)
-		}
-		return s == string(buf)
+		data, _ := cmd.PeekStdin()
+		return s == string(data)
 	}
 }
 

--- a/run/stub_executor.go
+++ b/run/stub_executor.go
@@ -64,9 +64,9 @@ func (e *StubExecutor) Output(cmd *Cmd) ([]byte, error) {
 		e.mu.Unlock()
 		n := len(matches)
 		if n == 0 {
-			return nil, fmt.Errorf("no registered stubs matching: %v", cmd)
+			return nil, fmt.Errorf("no registered stubs matching: %s", cmd.DebugString())
 		} else {
-			return nil, fmt.Errorf("wanted %d of only %d stubs matching: %v", n+1, n, cmd)
+			return nil, fmt.Errorf("wanted %d of only %d stubs matching: %s", n+1, n, cmd.DebugString())
 		}
 	}
 


### PR DESCRIPTION
- Added PeekStdin method for checking stdin w/out moving offset.
- Added DebugString method that fixes #21.