### PR TITLE
feat: support validations in prompter

### DIFF
--- a/ui/prompter.go
+++ b/ui/prompter.go
@@ -3,11 +3,46 @@ package ui
 // Prompter is an interface for types that prompt for user input.
 type Prompter interface {
 	// Confirm prompts for a boolean yes/no value.
-	Confirm(msg string, value bool, help string) (bool, error)
+	Confirm(msg string, value bool, opts ...PromptOpt) (bool, error)
 	// Input prompts for single string value.
-	Input(msg string, value string, help string) (string, error)
+	Input(msg string, value string, opts ...PromptOpt) (string, error)
 	// MultiSelect prompts for a slice of string values w/ a fixed set of options.
-	MultiSelect(msg string, options []string, values []string, help string) ([]string, error)
+	MultiSelect(msg string, options []string, values []string, opts ...PromptOpt) ([]string, error)
 	// Select prompts for single string value w/ a fixed set of options.
-	Select(msg string, options []string, value string, help string) (string, error)
+	Select(msg string, options []string, value string, opts ...PromptOpt) (string, error)
+}
+
+// PromptParams holds optional params for Prompter methods.
+type PromptParams struct {
+	// Help text to show when the user presses "?".
+	Help string
+	// One or more validation rules to be passed
+	// to [validate.KeyVal].
+	ValidationRules string
+}
+
+// PromptOpt allows setting optional prompt params.
+type PromptOpt func(params *PromptParams)
+
+// WithHelp sets the help text for a prompt.
+func WithHelp(text string) PromptOpt {
+	return func(params *PromptParams) {
+		params.Help = text
+	}
+}
+
+// WithValidation sets the validation rules for a prompt.
+func WithValidation(rules string) PromptOpt {
+	return func(params *PromptParams) {
+		params.ValidationRules = rules
+	}
+}
+
+// GetPromptParams returns the params for the given prompt ops.
+func GetPromptParams(opts ...PromptOpt) *PromptParams {
+	params := &PromptParams{}
+	for _, opt := range opts {
+		opt(params)
+	}
+	return params
 }

--- a/ui/prompter_test.go
+++ b/ui/prompter_test.go
@@ -1,0 +1,16 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPromptParams(t *testing.T) {
+	params := GetPromptParams(
+		WithHelp("This is a required field."),
+		WithValidation("required"),
+	)
+	assert.Equal(t, "This is a required field.", params.Help)
+	assert.Equal(t, "required", params.ValidationRules)
+}

--- a/ui/stub_prompter.go
+++ b/ui/stub_prompter.go
@@ -32,7 +32,7 @@ var (
 )
 
 // Confirm prompts for a boolean yes/no value.
-func (sp *StubPrompter) Confirm(msg string, value bool, help string) (bool, error) {
+func (sp *StubPrompter) Confirm(msg string, value bool, opts ...PromptOpt) (bool, error) {
 	prompt := Prompt{
 		Type:    PromptTypeConfirm,
 		Message: msg,
@@ -55,7 +55,7 @@ func (sp *StubPrompter) Confirm(msg string, value bool, help string) (bool, erro
 }
 
 // Input prompts for single string value.
-func (sp *StubPrompter) Input(msg string, value string, help string) (string, error) {
+func (sp *StubPrompter) Input(msg string, value string, opts ...PromptOpt) (string, error) {
 	prompt := Prompt{
 		Type:    PromptTypeInput,
 		Message: msg,
@@ -74,7 +74,7 @@ func (sp *StubPrompter) Input(msg string, value string, help string) (string, er
 }
 
 // MultiSelect prompts for a slice of string values w/ a fixed set of options.
-func (sp *StubPrompter) MultiSelect(msg string, options []string, values []string, help string) ([]string, error) {
+func (sp *StubPrompter) MultiSelect(msg string, options []string, values []string, opts ...PromptOpt) ([]string, error) {
 	prompt := Prompt{
 		Type:    PromptTypeMultiSelect,
 		Message: msg,
@@ -93,7 +93,7 @@ func (sp *StubPrompter) MultiSelect(msg string, options []string, values []strin
 }
 
 // Select prompts for single string value w/ a fixed set of options.
-func (sp *StubPrompter) Select(msg string, options []string, value string, help string) (string, error) {
+func (sp *StubPrompter) Select(msg string, options []string, value string, opts ...PromptOpt) (string, error) {
 	prompt := Prompt{
 		Type:    PromptTypeSelect,
 		Message: msg,

--- a/ui/stub_prompter_test.go
+++ b/ui/stub_prompter_test.go
@@ -12,7 +12,7 @@ func TestStubPrompter_Confirm(t *testing.T) {
 	ios := NewTestIOStreams()
 	prompter := NewStubPrompter(ios)
 
-	_, err := prompter.Confirm("Proceed?", false, "")
+	_, err := prompter.Confirm("Proceed?", false)
 	assert.ErrorContains(t, err, "no registered stubs matching")
 
 	prompter.RegisterStub(
@@ -24,15 +24,15 @@ func TestStubPrompter_Confirm(t *testing.T) {
 		RespondError(errors.New("boom")),
 	)
 
-	response, err := prompter.Confirm("Proceed?", false, "")
+	response, err := prompter.Confirm("Proceed?", false)
 	assert.NoError(t, err)
 	assert.Equal(t, true, response)
 
-	response, err = prompter.Confirm("Proceed?", false, "")
+	response, err = prompter.Confirm("Proceed?", false)
 	assert.ErrorContains(t, err, "boom")
 	assert.Equal(t, false, response)
 
-	_, err = prompter.Confirm("Proceed?", false, "")
+	_, err = prompter.Confirm("Proceed?", false)
 	assert.ErrorContains(t, err, "wanted 3 of only 2 stubs matching")
 
 	assert.Equal(t, []string{
@@ -44,7 +44,7 @@ func TestStubPrompter_Input(t *testing.T) {
 	ios := NewTestIOStreams()
 	prompter := NewStubPrompter(ios)
 
-	_, err := prompter.Input("Name:", "", "")
+	_, err := prompter.Input("Name:", "")
 	assert.ErrorContains(t, err, "no registered stubs matching")
 
 	prompter.RegisterStub(
@@ -56,15 +56,15 @@ func TestStubPrompter_Input(t *testing.T) {
 		RespondError(errors.New("boom")),
 	)
 
-	response, err := prompter.Input("Name:", "", "")
+	response, err := prompter.Input("Name:", "")
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", response)
 
-	response, err = prompter.Input("Name:", "", "")
+	response, err = prompter.Input("Name:", "")
 	assert.ErrorContains(t, err, "boom")
 	assert.Equal(t, "", response)
 
-	_, err = prompter.Input("Name:", "", "")
+	_, err = prompter.Input("Name:", "")
 	assert.ErrorContains(t, err, "wanted 3 of only 2 stubs matching")
 
 	assert.Equal(t, []string{
@@ -76,7 +76,7 @@ func TestStubPrompter_MultiSelect(t *testing.T) {
 	ios := NewTestIOStreams()
 	prompter := NewStubPrompter(ios)
 
-	_, err := prompter.MultiSelect("Colors:", nil, nil, "")
+	_, err := prompter.MultiSelect("Colors:", nil, nil)
 	assert.ErrorContains(t, err, "no registered stubs matching")
 
 	prompter.RegisterStub(
@@ -88,15 +88,15 @@ func TestStubPrompter_MultiSelect(t *testing.T) {
 		RespondError(errors.New("boom")),
 	)
 
-	response, err := prompter.MultiSelect("Colors:", nil, nil, "")
+	response, err := prompter.MultiSelect("Colors:", nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"red", "yellow", "blue"}, response)
 
-	response, err = prompter.MultiSelect("Colors:", nil, nil, "")
+	response, err = prompter.MultiSelect("Colors:", nil, nil)
 	assert.ErrorContains(t, err, "boom")
 	assert.Nil(t, response)
 
-	_, err = prompter.MultiSelect("Colors:", nil, nil, "")
+	_, err = prompter.MultiSelect("Colors:", nil, nil)
 	assert.ErrorContains(t, err, "wanted 3 of only 2 stubs matching")
 
 	assert.Equal(t, []string{
@@ -108,7 +108,7 @@ func TestStubPrompter_Select(t *testing.T) {
 	ios := NewTestIOStreams()
 	prompter := NewStubPrompter(ios)
 
-	_, err := prompter.Select("Country:", nil, "", "")
+	_, err := prompter.Select("Country:", nil, "")
 	assert.ErrorContains(t, err, "no registered stubs matching")
 
 	prompter.RegisterStub(
@@ -120,15 +120,15 @@ func TestStubPrompter_Select(t *testing.T) {
 		RespondError(errors.New("boom")),
 	)
 
-	response, err := prompter.Select("Country:", nil, "", "")
+	response, err := prompter.Select("Country:", nil, "")
 	assert.NoError(t, err)
 	assert.Equal(t, "US", response)
 
-	response, err = prompter.Select("Country:", nil, "", "")
+	response, err = prompter.Select("Country:", nil, "")
 	assert.ErrorContains(t, err, "boom")
 	assert.Equal(t, "", response)
 
-	_, err = prompter.Select("Country:", nil, "", "")
+	_, err = prompter.Select("Country:", nil, "")
 	assert.ErrorContains(t, err, "wanted 3 of only 2 stubs matching")
 
 	assert.Equal(t, []string{
@@ -153,7 +153,7 @@ func TestStubPrompter_VerifyWhenAllStubsMatched(t *testing.T) {
 		RespondBool(true),
 	)
 
-	_, err := prompter.Confirm("Proceed?", false, "")
+	_, err := prompter.Confirm("Proceed?", false)
 	assert.NoError(t, err)
 
 	prompter.VerifyStubs(mt)

--- a/ui/survey_prompter_test.go
+++ b/ui/survey_prompter_test.go
@@ -23,19 +23,19 @@ func TestSurveyPrompter_Confirm(t *testing.T) {
 
 	// Non-interactive sessions should not prompt - just return the default value.
 	ios.SetInteractive(false)
-	value, err := sp.Confirm("Explode?", true, "")
+	value, err := sp.Confirm("Explode?", true)
 	assert.NoError(t, err)
 	assert.Equal(t, true, value)
 
 	// Interactive sessions should prompt.
 	ios.SetInteractive(true)
-	_, err = sp.Confirm("Explode?", true, "")
+	_, err = sp.Confirm("Explode?", true)
 	assert.ErrorContains(t, err, "prompt error: boom")
 
 	// One stubbed out happy path for coverage stats.
 	// We're assuming that Survey works correctly and not testing actual interaction.
 	stubs.StubFunc(&surveyAsk, nil)
-	_, err = sp.Confirm("Explode?", true, "")
+	_, err = sp.Confirm("Explode?", true)
 	assert.NoError(t, err)
 	assert.Equal(t, true, value)
 }
@@ -49,13 +49,13 @@ func TestSurveyPrompter_Input(t *testing.T) {
 
 	// Non-interactive sessions should not prompt - just return the default value.
 	ios.SetInteractive(false)
-	value, err := sp.Input("Access Code", "12345", "")
+	value, err := sp.Input("Access Code", "12345")
 	assert.NoError(t, err)
 	assert.Equal(t, "12345", value)
 
 	// Interactive sessions should prompt.
 	ios.SetInteractive(true)
-	_, err = sp.Input("Access Code", "12345", "")
+	_, err = sp.Input("Access Code", "12345")
 	assert.ErrorContains(t, err, "prompt error: boom")
 }
 
@@ -68,13 +68,13 @@ func TestSurveyPrompter_MultiSelect(t *testing.T) {
 
 	// Non-interactive sessions should not prompt - just return the default value.
 	ios.SetInteractive(false)
-	value, err := sp.MultiSelect("Prefixes", []string{"a", "b", "c"}, []string{"a"}, "")
+	value, err := sp.MultiSelect("Prefixes", []string{"a", "b", "c"}, []string{"a"})
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"a"}, value)
 
 	// Interactive sessions should prompt.
 	ios.SetInteractive(true)
-	_, err = sp.MultiSelect("Prefixes", []string{"a", "b", "c"}, []string{"a"}, "")
+	_, err = sp.MultiSelect("Prefixes", []string{"a", "b", "c"}, []string{"a"})
 	assert.ErrorContains(t, err, "prompt error: boom")
 }
 
@@ -87,13 +87,13 @@ func TestSurveyPrompter_Select(t *testing.T) {
 
 	// Non-interactive sessions should not prompt - just return the default value.
 	ios.SetInteractive(false)
-	value, err := sp.Select("Prefixes", []string{"a", "b", "c"}, "a", "")
+	value, err := sp.Select("Prefixes", []string{"a", "b", "c"}, "a")
 	assert.NoError(t, err)
 	assert.Equal(t, "a", value)
 
 	// Interactive sessions should prompt.
 	ios.SetInteractive(true)
-	_, err = sp.Select("Prefixes", []string{"a", "b", "c"}, "a", "")
+	_, err = sp.Select("Prefixes", []string{"a", "b", "c"}, "a")
 	assert.ErrorContains(t, err, "prompt error: boom")
 }
 
@@ -103,4 +103,12 @@ func TestTrimSpace(t *testing.T) {
 	// Should pass anything else through
 	assert.Equal(t, 123, trimSpace(123))
 	assert.Equal(t, []string{"a", "b"}, trimSpace([]string{"a", "b"}))
+}
+
+func TestSurveyValidator(t *testing.T) {
+	validator := surveyValidator("MyKey", "required")
+	err := validator("some-value")
+	assert.NoError(t, err)
+	err = validator("")
+	assert.ErrorContains(t, err, "MyKey is a required field")
 }

--- a/ui/user_interface.go
+++ b/ui/user_interface.go
@@ -38,23 +38,23 @@ func (ui *UserInterface) Err(s string, args ...any) {
 **/
 
 // Confirm prompts for a boolean yes/no value.
-func (ui *UserInterface) Confirm(msg string, value bool, help string) (bool, error) {
-	return ui.Prompter.Confirm(msg, value, help)
+func (ui *UserInterface) Confirm(msg string, value bool, opts ...PromptOpt) (bool, error) {
+	return ui.Prompter.Confirm(msg, value, opts...)
 }
 
 // Input prompts for single string value.
-func (ui *UserInterface) Input(msg string, value string, help string) (string, error) {
-	return ui.Prompter.Input(msg, value, help)
+func (ui *UserInterface) Input(msg string, value string, opts ...PromptOpt) (string, error) {
+	return ui.Prompter.Input(msg, value, opts...)
 }
 
 // MultiSelect prompts for a slice of string values w/ a fixed set of options.
-func (ui *UserInterface) MultiSelect(msg string, options []string, values []string, help string) ([]string, error) {
-	return ui.Prompter.MultiSelect(msg, options, values, help)
+func (ui *UserInterface) MultiSelect(msg string, options []string, values []string, opts ...PromptOpt) ([]string, error) {
+	return ui.Prompter.MultiSelect(msg, options, values, opts...)
 }
 
 // Select prompts for single string value w/ a fixed set of options.
-func (ui *UserInterface) Select(msg string, options []string, value string, help string) (string, error) {
-	return ui.Prompter.Select(msg, options, value, help)
+func (ui *UserInterface) Select(msg string, options []string, value string, opts ...PromptOpt) (string, error) {
+	return ui.Prompter.Select(msg, options, value, opts...)
 }
 
 /**

--- a/ui/user_interface_test.go
+++ b/ui/user_interface_test.go
@@ -60,7 +60,7 @@ func TestUserInterface_Confirm(t *testing.T) {
 	ui.RegisterStub(MatchConfirm("Perform?"), RespondBool(true))
 	defer ui.VerifyStubs(t)
 
-	response, err := ui.Confirm("Perform?", false, "")
+	response, err := ui.Confirm("Perform?", false)
 	assert.NoError(t, err)
 	assert.Equal(t, true, response)
 }
@@ -70,7 +70,7 @@ func TestUserInterface_Input(t *testing.T) {
 	ui.RegisterStub(MatchInput("Name:"), RespondString("foo"))
 	defer ui.VerifyStubs(t)
 
-	response, err := ui.Input("Name:", "", "")
+	response, err := ui.Input("Name:", "")
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", response)
 }
@@ -80,7 +80,7 @@ func TestUserInterface_MultiSelect(t *testing.T) {
 	ui.RegisterStub(MatchMultiSelect("Color:"), RespondStringSlice([]string{"red"}))
 	defer ui.VerifyStubs(t)
 
-	response, err := ui.MultiSelect("Color:", nil, nil, "")
+	response, err := ui.MultiSelect("Color:", nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"red"}, response)
 }
@@ -90,7 +90,7 @@ func TestUserInterface_Select(t *testing.T) {
 	ui.RegisterStub(MatchSelect("Country:"), RespondString("US"))
 	defer ui.VerifyStubs(t)
 
-	response, err := ui.Select("Country:", nil, "", "")
+	response, err := ui.Select("Country:", nil, "")
 	assert.NoError(t, err)
 	assert.Equal(t, "US", response)
 }


### PR DESCRIPTION
Adds `ui.WithHelp()` and `ui.WithValidation()` variadic opts to `Prompter` methods. The `help` positional param has been removed.